### PR TITLE
LAU-318 Improve app insights telemetry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -337,7 +337,7 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.0.5'
 
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.1'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
 
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'

--- a/build.gradle
+++ b/build.gradle
@@ -281,8 +281,8 @@ def versions = [
         restAssured       : '4.4.0',
         serviceAuthVersion: '4.0.0',
         commonsIo         : '2.7',
-        cucumber          : '6.8.0'
-
+        cucumber          : '6.8.0',
+        fasterXmlJackson  : '2.13.2'
 ]
 
 ext.libraries = [
@@ -306,10 +306,6 @@ configurations.all {
 }
 
 dependencies {
-  // Fix for missing jackson-databind BOM when using version 2.13.2.1
-  // TODO: Remove as soon as https://github.com/FasterXML/jackson-databind/issues/3428 has been addressed.
-  implementation(platform("com.fasterxml.jackson:jackson-bom:2.13.2.20220324"))
-
   // exclude spring-cloud-context as it is already included in spring-cloud-starter-netflix-hystrix
   def withoutSpringCloudContext = {
     exclude group: 'org.springframework.cloud', module: 'spring-cloud-context'
@@ -340,8 +336,9 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.0.5'
 
+  implementation group: 'com.fasterxml.jackson', name: 'jackson-bom', version: versions.fasterXmlJackson, ext: 'pom'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.fasterXmlJackson
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.1'
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
 
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
   compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.1'

--- a/build.gradle
+++ b/build.gradle
@@ -306,6 +306,9 @@ configurations.all {
 }
 
 dependencies {
+  // Fix for missing jackson-databind BOM when using version 2.13.2.1
+  // TODO: Remove as soon as https://github.com/FasterXML/jackson-databind/issues/3428 has been addressed.
+  implementation(platform("com.fasterxml.jackson:jackson-bom:2.13.2.20220324"))
 
   // exclude spring-cloud-context as it is already included in spring-cloud-starter-netflix-hystrix
   def withoutSpringCloudContext = {

--- a/src/functionalTest/resources/application-functional.yaml
+++ b/src/functionalTest/resources/application-functional.yaml
@@ -34,4 +34,8 @@ idam:
     secret-cs: ${S2S_LAU_FT_SECRET:AAAAAAAAAAAAAAAA}
     name-cs: ${S2S_LAU_FT_NAME:lau_frontend}
 
+azure:
+  application-insights:
+    instrumentation-key: ${lau.AppInsightsInstrumentationKey:00000000-0000-0000-0000-000000000000}
+
 db.allow.delete.record: ${DB_ALLOW_DELETE_RECORD:true}

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -57,6 +57,9 @@ idam:
     secret: 12345678
     redirect_uri: http://localhost:3451/oauth2redirect
 
+azure:
+  application-insights:
+    instrumentation-key: ${lau.AppInsightsInstrumentationKey:00000000-0000-0000-0000-000000000000}
 
 authorised.services: lau_frontend
 authorised.roles: cft-audit-investigator

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/constants/CommonConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/constants/CommonConstants.java
@@ -4,7 +4,11 @@ public final class CommonConstants {
     public static final String SERVICE_AUTHORISATION_HEADER = "ServiceAuthorization";
     public static final String AUTHORISATION_HEADER = "Authorization";
 
-
+    public static final long PERF_TOLERANCE_THRESHOLD_MS = 1500;
+    public static final String PERF_THRESHOLD_MESSAGE_BELOW =
+        "Good: below threshold (" + PERF_TOLERANCE_THRESHOLD_MS + "ms)";
+    public static final String PERF_THRESHOLD_MESSAGE_ABOVE =
+        "Bad: above threshold (" + PERF_TOLERANCE_THRESHOLD_MS + "ms)";
 
     private CommonConstants() {
     }

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionController.java
@@ -167,10 +167,10 @@ public final class CaseActionController {
                     endTime,
                     size,
                     page);
+            final long timeStart = System.currentTimeMillis();
             verifyRequestActionParamsAreNotEmpty(inputParamsHolder);
             verifyRequestActionParamsConditions(inputParamsHolder);
 
-            final long timeStart = System.currentTimeMillis();
             final CaseActionGetResponse caseView = caseActionService.getCaseView(inputParamsHolder);
             final long timeEnd = System.currentTimeMillis();
             final String report = (timeEnd - timeStart) > PERF_TOLERANCE_THRESHOLD_MS

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionController.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.laubackend.cases.controllers;
 
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -18,6 +17,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.laubackend.cases.dto.ActionInputParamsHolder;
 import uk.gov.hmcts.reform.laubackend.cases.exceptions.InvalidRequestException;
+import uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights;
 import uk.gov.hmcts.reform.laubackend.cases.request.CaseActionPostRequest;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseActionGetResponse;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseActionPostResponse;
@@ -37,7 +37,14 @@ import static uk.gov.hmcts.reform.laubackend.cases.constants.CaseActionConstants
 import static uk.gov.hmcts.reform.laubackend.cases.constants.CaseActionConstants.START_TIME;
 import static uk.gov.hmcts.reform.laubackend.cases.constants.CaseActionConstants.USER_ID;
 import static uk.gov.hmcts.reform.laubackend.cases.constants.CommonConstants.AUTHORISATION_HEADER;
+import static uk.gov.hmcts.reform.laubackend.cases.constants.CommonConstants.PERF_THRESHOLD_MESSAGE_ABOVE;
+import static uk.gov.hmcts.reform.laubackend.cases.constants.CommonConstants.PERF_THRESHOLD_MESSAGE_BELOW;
+import static uk.gov.hmcts.reform.laubackend.cases.constants.CommonConstants.PERF_TOLERANCE_THRESHOLD_MS;
 import static uk.gov.hmcts.reform.laubackend.cases.constants.CommonConstants.SERVICE_AUTHORISATION_HEADER;
+import static uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent.GET_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION;
+import static uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent.GET_ACTIVITY_REQUEST_INFO;
+import static uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent.POST_ACTIVITY_REQUEST_EXCEPTION;
+import static uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent.POST_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION;
 import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifier.verifyRequestActionParamsConditions;
 import static uk.gov.hmcts.reform.laubackend.cases.utils.NotEmptyInputParamsVerifier.verifyRequestActionParamsAreNotEmpty;
 
@@ -51,6 +58,9 @@ public final class CaseActionController {
 
     @Autowired
     private CaseActionService caseActionService;
+
+    @Autowired
+    private AppInsights appInsights;
 
     @ApiOperation(tags = "POST end-points", value = "Save case action audits", notes = "This operation will "
             + "persist CCD case action entries which are posted in the request. Single CaseAction per request will "
@@ -91,12 +101,16 @@ public final class CaseActionController {
                     invalidRequestException.getMessage(),
                     invalidRequestException
             );
+            appInsights.trackEvent(POST_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION.toString(), appInsights.trackingMap(
+                "exception", invalidRequestException.getMessage()));
             return new ResponseEntity<>(null, BAD_REQUEST);
         } catch (final Exception exception) {
             log.error("saveCaseAction API call failed due to error - {}",
                     exception.getMessage(),
                     exception
             );
+            appInsights.trackEvent(POST_ACTIVITY_REQUEST_EXCEPTION.toString(), appInsights.trackingMap(
+                "exception", exception.getMessage()));
             return new ResponseEntity<>(null, INTERNAL_SERVER_ERROR);
         }
     }
@@ -156,8 +170,13 @@ public final class CaseActionController {
             verifyRequestActionParamsAreNotEmpty(inputParamsHolder);
             verifyRequestActionParamsConditions(inputParamsHolder);
 
+            final long timeStart = System.currentTimeMillis();
             final CaseActionGetResponse caseView = caseActionService.getCaseView(inputParamsHolder);
-
+            final long timeEnd = System.currentTimeMillis();
+            final String report = (timeEnd - timeStart) > PERF_TOLERANCE_THRESHOLD_MS
+                ? PERF_THRESHOLD_MESSAGE_ABOVE : PERF_THRESHOLD_MESSAGE_BELOW;
+            appInsights.trackEvent(GET_ACTIVITY_REQUEST_INFO.toString(), appInsights.trackingMap(
+                "GET /audit/caseAction", report));
             return new ResponseEntity<>(caseView, OK);
         } catch (final InvalidRequestException invalidRequestException) {
             log.error(
@@ -165,6 +184,8 @@ public final class CaseActionController {
                     invalidRequestException.getMessage(),
                     invalidRequestException
             );
+            appInsights.trackEvent(GET_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION.toString(), appInsights.trackingMap(
+                "exception", invalidRequestException.getMessage()));
             return new ResponseEntity<>(null, BAD_REQUEST);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseSearchController.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseSearchController.java
@@ -156,10 +156,10 @@ public class CaseSearchController {
                     endTime,
                     size,
                     page);
+            final long timeStart = System.currentTimeMillis();
             verifyRequestSearchParamsAreNotEmpty(inputParamsHolder);
             verifyRequestSearchParamsConditions(inputParamsHolder);
 
-            final long timeStart = System.currentTimeMillis();
             final CaseSearchGetResponse caseSearch = caseSearchService.getCaseSearch(inputParamsHolder);
             final long timeEnd = System.currentTimeMillis();
             final String report = (timeEnd - timeStart) > PERF_TOLERANCE_THRESHOLD_MS

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsights.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.laubackend.cases.insights;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class AppInsights implements EventRepository {
+
+    private final TelemetryClient telemetry;
+
+    @Autowired
+    public AppInsights(@Value("${azure.application-insights.instrumentation-key}")
+                           String instrumentationKey,
+                       TelemetryClient telemetry) {
+        TelemetryConfiguration.getActive().setInstrumentationKey(instrumentationKey);
+        telemetry.getContext().getComponent().setVersion(getClass().getPackage().getImplementationVersion());
+        this.telemetry = telemetry;
+    }
+
+    @Override
+    public void trackEvent(String name, Map<String, String> properties) {
+        telemetry.trackEvent(name, properties,null);
+    }
+
+    public Map<String, String> trackingMap(String propertyName, String propertyToTrack) {
+        HashMap<String, String> trackMap = new HashMap<>();
+        trackMap.put(propertyName, propertyToTrack);
+        return trackMap;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsEvent.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.laubackend.cases.insights;
+
+public enum AppInsightsEvent {
+    REQUEST_SENT("Request made to: "),
+    REST_CLIENT_EXCEPTION("RestClientException: "),
+    ILLEGAL_ARGUMENT_EXCEPTION("IllegalArgumentException: ");
+
+    private String displayName;
+
+    AppInsightsEvent(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsEvent.java
@@ -1,9 +1,15 @@
 package uk.gov.hmcts.reform.laubackend.cases.insights;
 
 public enum AppInsightsEvent {
-    REQUEST_SENT("Request made to: "),
-    REST_CLIENT_EXCEPTION("RestClientException: "),
-    ILLEGAL_ARGUMENT_EXCEPTION("IllegalArgumentException: ");
+    GET_SEARCH_REQUEST_INFO("Audit Case Search GET Request Info: "),
+    GET_SEARCH_REQUEST_INVALID_REQUEST_EXCEPTION("Audit GET Case Search Requst InvalidRequestException: "),
+    GET_ACTIVITY_REQUEST_INFO("Audit GET Case Activity Request Info: "),
+    GET_ACTIVITY_REQUEST_EXCEPTION("Audit GET Case Activity Request Exception: "),
+    GET_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION("Audit GET Case Activity Requst InvalidRequestException: "),
+    POST_SEARCH_REQUEST_EXCEPTION("Audit POST Case Search Request Exception: "),
+    POST_SEARCH_REQUEST_INVALID_REQUEST_EXCEPTION("Audit POST Case Search Requst InvalidRequestException: "),
+    POST_ACTIVITY_REQUEST_EXCEPTION("Audit POST Case Activity Request Exception: "),
+    POST_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION("Audit POST Case Activity Requst InvalidRequestException: ");
 
     private String displayName;
 

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/insights/EventRepository.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.laubackend.cases.insights;
+
+import java.util.Map;
+
+public interface EventRepository {
+
+    void trackEvent(String name, Map<String, String> properties);
+}

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/config/SwaggerGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/config/SwaggerGeneratorTest.java
@@ -4,10 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
@@ -53,7 +51,7 @@ class SwaggerGeneratorTest {
     private IdamApi idamApi;
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         this.mvc = webAppContextSetup(webAppContext).build();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/config/SwaggerGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/config/SwaggerGeneratorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.laubackend.cases.config;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
 import uk.gov.hmcts.reform.laubackend.cases.authorization.AuthService;
 import uk.gov.hmcts.reform.laubackend.cases.authorization.AuthorisedServices;
@@ -20,19 +22,20 @@ import java.nio.file.Paths;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 /**
  * Built-in feature which saves service's swagger specs in temporary directory.
  * Each travis run on master should automatically save and upload (if updated) documentation.
  */
-@SpringJUnitWebConfig
 @SpringBootTest
-@AutoConfigureMockMvc
 @SuppressWarnings({"PMD.UnusedPrivateField"})
 class SwaggerGeneratorTest {
 
-    @Autowired
     private MockMvc mvc;
+
+    @Autowired
+    private WebApplicationContext webAppContext;
 
     @MockBean
     private AuthService authService;
@@ -48,6 +51,11 @@ class SwaggerGeneratorTest {
 
     @MockBean
     private IdamApi idamApi;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = webAppContextSetup(webAppContext).build();
+    }
 
     @DisplayName("Generate swagger documentation")
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionControllerTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.laubackend.cases.dto.ActionLog;
+import uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights;
 import uk.gov.hmcts.reform.laubackend.cases.request.CaseActionPostRequest;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseActionGetResponse;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseActionPostResponse;
@@ -16,10 +17,12 @@ import uk.gov.hmcts.reform.laubackend.cases.service.CaseActionService;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -33,6 +36,9 @@ class CaseActionControllerTest {
 
     @Mock
     private CaseActionService caseActionService;
+
+    @Mock
+    private AppInsights appInsights;
 
     @InjectMocks
     private CaseActionController caseActionController;
@@ -61,6 +67,7 @@ class CaseActionControllerTest {
         );
 
         verify(caseActionService, times(1)).getCaseView(any());
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(OK);
     }
 
@@ -79,6 +86,7 @@ class CaseActionControllerTest {
                 null
         );
 
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -106,6 +114,7 @@ class CaseActionControllerTest {
         );
 
         verify(caseActionService, times(1)).saveCaseAction(actionLog);
+        verifyNoInteractions(appInsights); // no telementry for successful posts.
         assertThat(responseEntity.getStatusCode()).isEqualTo(CREATED);
     }
 
@@ -122,6 +131,7 @@ class CaseActionControllerTest {
 
         );
 
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -145,6 +155,7 @@ class CaseActionControllerTest {
                 caseActionPostRequest
         );
 
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseActionControllerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.laubackend.cases.dto.ActionLog;
 import uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights;
+import uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent;
 import uk.gov.hmcts.reform.laubackend.cases.request.CaseActionPostRequest;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseActionGetResponse;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseActionPostResponse;
@@ -18,6 +19,7 @@ import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,6 +34,7 @@ import static org.springframework.http.HttpStatus.OK;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SuppressWarnings("PMD.LawOfDemeter")
 class CaseActionControllerTest {
 
     @Mock
@@ -67,7 +70,8 @@ class CaseActionControllerTest {
         );
 
         verify(caseActionService, times(1)).getCaseView(any());
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1))
+            .trackEvent(eq(AppInsightsEvent.GET_ACTIVITY_REQUEST_INFO.toString()), any());
         assertThat(responseEntity.getStatusCode()).isEqualTo(OK);
     }
 
@@ -86,7 +90,8 @@ class CaseActionControllerTest {
                 null
         );
 
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1))
+            .trackEvent(eq(AppInsightsEvent.GET_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION.toString()),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -131,7 +136,8 @@ class CaseActionControllerTest {
 
         );
 
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1))
+            .trackEvent(eq(AppInsightsEvent.POST_ACTIVITY_REQUEST_INVALID_REQUEST_EXCEPTION.toString()),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -155,7 +161,8 @@ class CaseActionControllerTest {
                 caseActionPostRequest
         );
 
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1))
+            .trackEvent(eq(AppInsightsEvent.POST_ACTIVITY_REQUEST_EXCEPTION.toString()),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseSearchControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseSearchControllerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.laubackend.cases.dto.SearchLog;
 import uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights;
+import uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent;
 import uk.gov.hmcts.reform.laubackend.cases.request.CaseSearchPostRequest;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseSearchGetResponse;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseSearchPostResponse;
@@ -20,6 +21,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -31,9 +33,9 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
 
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals"})
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SuppressWarnings({"PMD.LawOfDemeter", "PMD.AvoidDuplicateLiterals"})
 class CaseSearchControllerTest {
 
     @Mock
@@ -66,7 +68,8 @@ class CaseSearchControllerTest {
         );
 
         verify(caseSearchService, times(1)).getCaseSearch(any());
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1))
+            .trackEvent(eq(AppInsightsEvent.GET_SEARCH_REQUEST_INFO.toString()), anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(OK);
     }
 
@@ -83,7 +86,8 @@ class CaseSearchControllerTest {
                 null
         );
 
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1))
+            .trackEvent(eq(AppInsightsEvent.GET_SEARCH_REQUEST_INVALID_REQUEST_EXCEPTION.toString()),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -129,7 +133,8 @@ class CaseSearchControllerTest {
                 null
         );
 
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1))
+            .trackEvent(eq(AppInsightsEvent.POST_SEARCH_REQUEST_INVALID_REQUEST_EXCEPTION.toString()),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -151,7 +156,8 @@ class CaseSearchControllerTest {
                 null
         );
 
-        verify(appInsights, times(1)).trackEvent(any(),anyMap());
+        verify(appInsights, times(1)).trackEvent(
+            eq(AppInsightsEvent.POST_SEARCH_REQUEST_EXCEPTION.toString()),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(INTERNAL_SERVER_ERROR);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseSearchControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/CaseSearchControllerTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.laubackend.cases.dto.SearchLog;
+import uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights;
 import uk.gov.hmcts.reform.laubackend.cases.request.CaseSearchPostRequest;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseSearchGetResponse;
 import uk.gov.hmcts.reform.laubackend.cases.response.CaseSearchPostResponse;
@@ -18,10 +19,12 @@ import static org.apache.commons.lang3.RandomStringUtils.random;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -35,6 +38,9 @@ class CaseSearchControllerTest {
 
     @Mock
     private CaseSearchService caseSearchService;
+
+    @Mock
+    private AppInsights appInsights;
 
     @InjectMocks
     private CaseSearchController caseSearchController;
@@ -60,6 +66,7 @@ class CaseSearchControllerTest {
         );
 
         verify(caseSearchService, times(1)).getCaseSearch(any());
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(OK);
     }
 
@@ -76,6 +83,7 @@ class CaseSearchControllerTest {
                 null
         );
 
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -102,6 +110,7 @@ class CaseSearchControllerTest {
         );
 
         verify(caseSearchService, times(1)).saveCaseSearch(caseSearchPostRequest);
+        verifyNoInteractions(appInsights); // no telementry for successful posts.
         assertThat(responseEntity.getStatusCode()).isEqualTo(CREATED);
     }
 
@@ -120,6 +129,7 @@ class CaseSearchControllerTest {
                 null
         );
 
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(BAD_REQUEST);
     }
 
@@ -141,6 +151,7 @@ class CaseSearchControllerTest {
                 null
         );
 
+        verify(appInsights, times(1)).trackEvent(any(),anyMap());
         assertThat(responseEntity.getStatusCode()).isEqualTo(INTERNAL_SERVER_ERROR);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsTest.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.reform.laubackend.cases.insights;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.TelemetryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.util.Assert;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent.REQUEST_SENT;
+
+class AppInsightsTest {
+    private uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights classUnderTest;
+    private static final String APPINSIGHTS_INSTRUMENT_KEY = "key";
+
+    @Mock
+    private TelemetryClient telemetryClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        TelemetryContext telemetryContext = new TelemetryContext();
+        telemetryContext.setInstrumentationKey("some-key");
+        doReturn(telemetryContext).when(telemetryClient).getContext();
+        classUnderTest = new uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights(APPINSIGHTS_INSTRUMENT_KEY, telemetryClient);
+    }
+
+    @Test
+    void trackRequest() {
+        try {
+            classUnderTest.trackEvent(REQUEST_SENT.toString(), classUnderTest.trackingMap("uri", "http://testurl.com"));
+        } catch (Exception exp) {
+            fail("classUnderTest.trackEvent() failed.");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void testTelemetry() {
+        TelemetryContext telemetryContext = new TelemetryContext();
+        telemetryContext.setInstrumentationKey("key");
+
+        TelemetryClient telemetryClient = mock(TelemetryClient.class);
+        when(telemetryClient.getContext()).thenReturn(telemetryContext);
+
+        AppInsights appInsights = new AppInsights(APPINSIGHTS_INSTRUMENT_KEY, telemetryClient);
+
+        Assert.isInstanceOf(AppInsights.class, appInsights);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/insights/AppInsightsTest.java
@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent.REQUEST_SENT;
+import static uk.gov.hmcts.reform.laubackend.cases.insights.AppInsightsEvent.GET_ACTIVITY_REQUEST_EXCEPTION;
 
 class AppInsightsTest {
-    private uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights classUnderTest;
+    private AppInsights classUnderTest;
     private static final String APPINSIGHTS_INSTRUMENT_KEY = "key";
 
     @Mock
@@ -27,13 +27,14 @@ class AppInsightsTest {
         TelemetryContext telemetryContext = new TelemetryContext();
         telemetryContext.setInstrumentationKey("some-key");
         doReturn(telemetryContext).when(telemetryClient).getContext();
-        classUnderTest = new uk.gov.hmcts.reform.laubackend.cases.insights.AppInsights(APPINSIGHTS_INSTRUMENT_KEY, telemetryClient);
+        classUnderTest = new AppInsights(APPINSIGHTS_INSTRUMENT_KEY, telemetryClient);
     }
 
     @Test
     void trackRequest() {
         try {
-            classUnderTest.trackEvent(REQUEST_SENT.toString(), classUnderTest.trackingMap("uri", "http://testurl.com"));
+            classUnderTest.trackEvent(GET_ACTIVITY_REQUEST_EXCEPTION.toString(),
+                                      classUnderTest.trackingMap("exception", "Error"));
         } catch (Exception exp) {
             fail("classUnderTest.trackEvent() failed.");
         }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -41,6 +41,9 @@ spring:
   flyway:
     locations: classpath:h2
 
+azure:
+  application-insights:
+    instrumentation-key: ${lau.AppInsightsInstrumentationKey:00000000-0000-0000-0000-000000000000}
 
 flyway:
   noop:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-318


### Change description ###
Add application insights telementry to...
1. Report on execeptions
2. Count GET controller actions which are above or below 1.5 seconds Reform page request threshold.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
