### PR TITLE
LAU-531: Update socket timeout to 60 seconds.

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ spring:
       maxLifetime: 7200000
       connectionTimeout: 60000
       data-source-properties:
-        socketTimeout: 8
+        socketTimeout: 60
   #    tomcat:
   #      max-active: 10
   #      max-idle: 10


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-531


### Change description ###
Update SQL socket timeout to 60 seconds to allow long running sql for case searches.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
