### PR TITLE
LAU-646 upgrade vulnerable to CVE-2023-20863 libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,7 +286,7 @@ def versions = [
         commonsIo         : '2.7',
         cucumber          : '6.8.0',
         fasterXmlJackson  : '2.14.2',
-        springFramework   : '5.3.26',
+        springFramework   : '5.3.27',
         springCloud       : '3.1.2',
         log4j             : '2.17.2',
         springSecurity    : '5.7.5'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-646

### Change description ###

Minor versions bump to address CVE-2023-20863 vulnerability

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```