### PR TITLE
LAU-733 default is too small to migrate aat

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,4 +11,8 @@
     <notes>Affects Spring-Kafka which we do not have, nor use: https://spring.io/security/cve-2023-34040</notes>
     <cve>CVE-2023-34040</cve>
   </suppress>
+  <suppress>
+    <notes>No fix till netty 5 release or fix applied to netty 4</notes>
+    <cve>CVE-2023-4586</cve>
+  </suppress>
 </suppressions>

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -49,6 +49,8 @@ module "lau-case-db-flexible" {
 
   common_tags = var.common_tags
 
+  pgsql_storage_mb = 131072
+
   pgsql_admin_username = "lauadmin"
   pgsql_version   = "15"
 
@@ -140,5 +142,3 @@ resource "azurerm_key_vault_secret" "POSTGRES_PORT_FLEXIBLE" {
   name      = "${var.component}-POSTGRES-PORT-FLEXIBLE"
   value     =  var.postgresql_flexible_server_port
 }
-
-


### PR DESCRIPTION
### JIRA link (if applicable) ###

LAU-733

### Change description ###

Default space on flexible is not enough for aat to migrate.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```