### PR TITLE
Revert fortify-client to regular versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,7 +347,7 @@ dependencies {
   testImplementation group: 'org.codehaus.sonar-plugins', name: 'sonar-pitest-plugin', version: '0.5'
   testImplementation group: 'org.testcontainers', name: 'testcontainers', version: versions.testcontainers
   testImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testcontainers
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '6623c6c811', classifier: 'all'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.2', classifier: 'all'
   testImplementation group: 'org.testcontainers', name: 'testcontainers', version: versions.testcontainers
   testImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testcontainers
   testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '3.0.1'


### PR DESCRIPTION
### Change description ###
Revert fortify-client to use regular versions as they release a new one with the updates needed for spring-boot 3.3.0
