### PR TITLE
Verify request end timestamps is available for Challenged (auto-apprved) and Specific (approved)

### DIFF
--- a/src/integrationTest/resources/features/get_access_request.feature
+++ b/src/integrationTest/resources/features/get_access_request.feature
@@ -4,11 +4,11 @@ Feature: The application's GET accessRequest endpoint
     Given LAU backend application is healthy
     When I POST multiple Access Request records to "/audit/accessRequest" endpoint once using data:
       |requestType|userId|caseRef         |reason|action        |requestEndTimestamp     |timestamp               |
-      |SPECIFIC   |123   |1234567890123456|nosy  |CREATED       |2024-02-03T22:20:05.023Z|2024-02-25T22:20:05.023Z|
-      |SPECIFIC   |123   |1234567890123456|nosy  |REJECTED      |2024-02-03T22:20:05.023Z|2024-02-25T22:20:05.023Z|
+      |SPECIFIC   |123   |1234567890123456|nosy  |CREATED       |                        |2024-02-25T22:20:05.023Z|
+      |SPECIFIC   |123   |1234567890123456|nosy  |REJECTED      |                        |2024-02-25T22:20:05.023Z|
       |CHALLENGED |456   |1234567890123456|fun   |AUTO-APPROVED |2024-02-03T22:20:05.023Z|2024-03-20T22:20:05.023Z|
       |CHALLENGED |456   |6543210987654321|meh   |AUTO-APPROVED |2024-02-03T22:20:05.023Z|2024-04-15T22:20:05.023Z|
-      |SPECIFIC   |789   |6543210987654321|meh   |CREATED       |2024-02-03T22:20:05.023Z|2024-05-10T22:20:05.023Z|
+      |SPECIFIC   |789   |6543210987654321|meh   |CREATED       |                        |2024-05-10T22:20:05.023Z|
       |SPECIFIC   |789   |6543210987654321|      |APPROVED      |2024-02-03T22:20:05.023Z|2024-05-10T22:20:05.023Z|
       |CHALLENGED |789   |1122334455667788|nosy  |AUTO-APPROVED |2024-02-03T22:20:05.023Z|2024-06-05T22:20:05.023Z|
       |CHALLENGED |789   |1122334455667788|nosy  |AUTO-APPROVED |2024-02-03T22:20:05.023Z|2024-08-02T22:20:05.023Z|
@@ -23,8 +23,8 @@ Feature: The application's GET accessRequest endpoint
       |endTimestamp  |2024-03-02T22:01:00|
     Then the list of accessRequest records returned is (expected total 2):
       |requestType|userId|caseRef         |reason|action        |requestEndTimestamp     |timestamp               |
-      |SPECIFIC   |123   |1234567890123456|nosy  |REJECTED      |2024-02-03T22:20:05.023Z|2024-02-25T22:20:05.023Z|
-      |SPECIFIC   |123   |1234567890123456|nosy  |CREATED       |2024-02-03T22:20:05.023Z|2024-02-25T22:20:05.023Z|
+      |SPECIFIC   |123   |1234567890123456|nosy  |REJECTED      |                        |2024-02-25T22:20:05.023Z|
+      |SPECIFIC   |123   |1234567890123456|nosy  |CREATED       |                        |2024-02-25T22:20:05.023Z|
 
 
   Scenario: The backend is able to process accessRequest GET requests by caseRef
@@ -35,7 +35,7 @@ Feature: The application's GET accessRequest endpoint
     Then the list of accessRequest records returned is (expected total 3):
       |requestType|userId|caseRef         |reason|action       |requestEndTimestamp     |timestamp               |
       |SPECIFIC   |789   |6543210987654321|      |APPROVED     |2024-02-03T22:20:05.023Z|2024-05-10T22:20:05.023Z|
-      |SPECIFIC   |789   |6543210987654321|meh   |CREATED      |2024-02-03T22:20:05.023Z|2024-05-10T22:20:05.023Z|
+      |SPECIFIC   |789   |6543210987654321|meh   |CREATED      |                        |2024-05-10T22:20:05.023Z|
       |CHALLENGED |456   |6543210987654321|meh   |AUTO-APPROVED|2024-02-03T22:20:05.023Z|2024-04-15T22:20:05.023Z|
 
   Scenario: The backend is able to process accessRequest GET requests by requestType

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/utils/InputParamsVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/utils/InputParamsVerifier.java
@@ -34,6 +34,7 @@ import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifierHelp
 import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifierHelper.verifyCaseTypeId;
 import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifierHelper.verifyChallengedRequestIsAutoApproved;
 import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifierHelper.verifyReasonPopulated;
+import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifierHelper.verifyRequestEndPopulated;
 import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifierHelper.verifyTimestamp;
 import static uk.gov.hmcts.reform.laubackend.cases.utils.InputParamsVerifierHelper.verifyUserId;
 
@@ -110,6 +111,7 @@ public final class InputParamsVerifier {
 
         verifyChallengedRequestIsAutoApproved(accessRequestLog);
         verifyReasonPopulated(accessRequestLog);
+        verifyRequestEndPopulated(accessRequestLog);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/cases/utils/InputParamsVerifierHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/cases/utils/InputParamsVerifierHelper.java
@@ -83,8 +83,28 @@ public final class InputParamsVerifierHelper {
             || (accessRequestLog.getRequestType() == AccessRequestType.SPECIFIC
             && accessRequestLog.getAction() == AccessRequestAction.CREATED
             && accessRequestLog.getReason() == null)) {
-            throw new InvalidRequestException("CHALLENGED and SPECIFIC (CREATED) request type must have a reason",
-                                              BAD_REQUEST);
+            throw new InvalidRequestException(
+                "CHALLENGED and SPECIFIC (CREATED) request type must have a reason",
+                BAD_REQUEST
+            );
         }
+    }
+
+    public static void verifyRequestEndPopulated(AccessRequestLog accessRequestLog) throws InvalidRequestException {
+        if (accessRequestLog.getRequestType() == AccessRequestType.CHALLENGED
+            && isEmpty(accessRequestLog.getRequestEnd())
+            || (accessRequestLog.getRequestType() == AccessRequestType.SPECIFIC
+            && accessRequestLog.getAction() == AccessRequestAction.APPROVED
+            && isEmpty(accessRequestLog.getRequestEnd()))
+            || (accessRequestLog.getRequestType() == AccessRequestType.SPECIFIC
+            && (accessRequestLog.getAction() == AccessRequestAction.CREATED
+            || accessRequestLog.getAction() == AccessRequestAction.REJECTED)
+            && !isEmpty(accessRequestLog.getRequestEnd()))) {
+            throw new InvalidRequestException(
+                "CHALLENGED and SPECIFIC (APPROVED) request types must have requestEnd", BAD_REQUEST
+            );
+
+        }
+
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/AccessRequestControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/controllers/AccessRequestControllerTest.java
@@ -43,6 +43,7 @@ class AccessRequestControllerTest {
             .requestType(AccessRequestType.CHALLENGED)
             .action(AccessRequestAction.AUTO_APPROVED)
             .reason("super cool reason")
+            .requestEnd("123")
             .userId("1234-abcd")
             .build();
 
@@ -75,6 +76,7 @@ class AccessRequestControllerTest {
             .action(AccessRequestAction.AUTO_APPROVED)
             .reason("some cool reason")
             .userId("1234-abcd")
+            .requestEnd("123")
             .build();
 
         when(accessRequestService.save(any())).thenThrow(new RuntimeException("Test exception"));

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/cases/utils/AccessRequestInputParamsVerifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/cases/utils/AccessRequestInputParamsVerifierTest.java
@@ -46,7 +46,7 @@ class AccessRequestInputParamsVerifierTest {
         accessRequestLog.setRequestType(AccessRequestType.SPECIFIC);
         accessRequestLog.setAction(AccessRequestAction.CREATED);
 
-        assertThrows(InvalidRequestException.class,() ->
+        assertThrows(InvalidRequestException.class, () ->
             InputParamsVerifier.verifyChallengedAccessRequest(accessRequestLog));
     }
 
@@ -69,5 +69,51 @@ class AccessRequestInputParamsVerifierTest {
 
         assertDoesNotThrow(() -> InputParamsVerifier.verifyChallengedAccessRequest(accessRequestLog));
     }
+
+    @Test
+    void verifyAccessRequestThrowsForChallengedRequestWithoutEnd() {
+        AccessRequestLog accessRequestLog = new AccessRequestLog();
+        accessRequestLog.setRequestType(AccessRequestType.CHALLENGED);
+        accessRequestLog.setAction(AccessRequestAction.AUTO_APPROVED);
+        accessRequestLog.setReason("Some reason");
+
+        assertThrows(InvalidRequestException.class, ()
+            -> InputParamsVerifier.verifyChallengedAccessRequest(accessRequestLog));
+    }
+
+    @Test
+    void verifyAccessRequestThrowForCSpecificRequestWithEnd() {
+        AccessRequestLog accessRequestLog = new AccessRequestLog();
+        accessRequestLog.setRequestType(AccessRequestType.SPECIFIC);
+        accessRequestLog.setAction(AccessRequestAction.CREATED);
+        accessRequestLog.setReason("Some reason");
+        accessRequestLog.setRequestEnd("2023-10-12T12:12:12.000");
+
+        assertThrows(InvalidRequestException.class, () ->
+            InputParamsVerifier.verifyChallengedAccessRequest(accessRequestLog));
+    }
+
+    @Test
+    void verifyAccessRequestDoesNotThrowForSpecificRequestWithEnd() {
+        AccessRequestLog accessRequestLog = new AccessRequestLog();
+        accessRequestLog.setRequestType(AccessRequestType.SPECIFIC);
+        accessRequestLog.setAction(AccessRequestAction.APPROVED);
+        accessRequestLog.setReason("Some reason");
+        accessRequestLog.setRequestEnd("2023-10-12T12:12:12.000");
+
+        assertDoesNotThrow(() -> InputParamsVerifier.verifyChallengedAccessRequest(accessRequestLog));
+    }
+
+    @Test
+    void verifyAccessRequestDoesNotThrowForChallengedRequestWithEnd() {
+        AccessRequestLog accessRequestLog = new AccessRequestLog();
+        accessRequestLog.setRequestType(AccessRequestType.CHALLENGED);
+        accessRequestLog.setAction(AccessRequestAction.AUTO_APPROVED);
+        accessRequestLog.setReason("Some reason");
+        accessRequestLog.setRequestEnd("2023-10-12T12:12:12.000");
+
+        assertDoesNotThrow(() -> InputParamsVerifier.verifyChallengedAccessRequest(accessRequestLog));
+    }
+
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Verify request end timestamps is available for Challenged (auto-apprved) and Specific (approved)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```