### PR TITLE
Double the size after automatic storage expansion

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,1 +1,2 @@
-subnet_suffix = "expanded"
+subnet_suffix    = "expanded"
+pgsql_storage_mb = 262144


### PR DESCRIPTION
### Change description ###
Azure automatically doubled the size because usage was 80%. Expanding in terraform so it does not try to delete


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```