### PR TITLE
Onboard CVE dashboard intake

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@cve-dashboard")
 
 import uk.gov.hmcts.contino.GradleBuilder
 
@@ -44,6 +44,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 GradleBuilder builder = new GradleBuilder(this, product)
 
 withPipeline(type, product, component) {
+    enableCveDashboardIngestion()
 
     env.TEST_URL = "http://lau-case-backend-aat.service.core-compute-aat.internal"
     env.TEST_S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"


### PR DESCRIPTION
## Summary
- use the CVE dashboard Jenkins library branch
- enable CVE dashboard ingestion for the CNP pipeline

## Testing
- Not run; Jenkins pipeline configuration only